### PR TITLE
Defer photo query until PhotosList is rendered to avoid unnecessary fetch

### DIFF
--- a/frontend/src/components/AlbumsListItem.tsx
+++ b/frontend/src/components/AlbumsListItem.tsx
@@ -6,19 +6,18 @@ import PhotosList from "./PhotosList";
 import ConfirmDialog from "./ConfirmDialog";
 import { useState } from "react";
 import type { Album } from "../types/types";
+import { useHasPhotos } from "../hooks/useHasPhotos";
+import { useShouldRunQuery } from "../hooks/useShouldRunQuery";
 function AlbumsListItem({album}: {
     album: Album
 }) {
     console.log("albumlistitem")
     const [deleteAlbum, {isLoading: isDeletingAlbum}] = useDeleteAlbumsMutation()
-    //const {data: photos} = useFetchPhotosQuery(album)// there were only 8 albumlistitem renders when i expanded user if i removed this. else there were 18
-    //but this causes another issue now when i add a photo to an album and immediately delete that album it gets deleted no warning screen.
-    //cause when we add photo only photo listen item rerenders not albumlist which has the fetchalbums query we would have to run it to get the updated photos count
-    //one  idea is to invalidate that album so fetchalbums is called again
-    //but photos and albums are separate apis and do not share a cache 
-    //read a single api slice is better pattern
+    const {shouldRunQuery, onExpand} = useShouldRunQuery()
+    const hasPhotos = useHasPhotos(album, shouldRunQuery);
+    
     const handleDeleteAlbum = (album: Album) => {
-        if(album._count.photos){ //optional chaining
+        if(hasPhotos){ 
             setIsOpen(true)
         }
         else{
@@ -38,7 +37,7 @@ function AlbumsListItem({album}: {
     return (
     <>
         <ExpandablePanel header={header}>
-            <PhotosList album={album}/>
+            <PhotosList album={album} onExpand={onExpand}/>
         </ExpandablePanel>
         <ConfirmDialog 
         open={isOpen} 

--- a/frontend/src/components/PhotosList.tsx
+++ b/frontend/src/components/PhotosList.tsx
@@ -5,10 +5,15 @@ import ImageList from '@mui/material/ImageList';
 import type { Album } from "../types/types";
 import { Typography } from "@mui/material";
 import { Header } from "./Header";
-function PhotosList({album}: {
-        album: Album
+import { useEffect } from "react";
+function PhotosList({album, onExpand}: {
+        album: Album,
+        onExpand: () => void
     }) {
     const {isFetching, error, data} = useFetchPhotosQuery(album)
+    useEffect(() => {
+        onExpand()
+    }, [])
     const [addPhotos, {isLoading: isAddingPhotos}] = useAddPhotosMutation()
 
     const handleAddPhotos = () => addPhotos(album)

--- a/frontend/src/hooks/useHasPhotos.ts
+++ b/frontend/src/hooks/useHasPhotos.ts
@@ -1,0 +1,12 @@
+import type { Album } from "../types/types";
+import { useFetchPhotosQuery } from "../store";
+import { skipToken } from "@reduxjs/toolkit/query";
+export function useHasPhotos(album: Album, shouldRunQuery: boolean) {
+  const initialCount = album._count.photos;
+
+  const { data, isSuccess } = useFetchPhotosQuery(shouldRunQuery ? album : skipToken);
+  console.log("hasPhotos", data?.length, "initialcount", initialCount, shouldRunQuery, isSuccess);
+  
+
+  return isSuccess ? !!data?.length : initialCount > 0;
+}

--- a/frontend/src/hooks/useShouldRunQuery.ts
+++ b/frontend/src/hooks/useShouldRunQuery.ts
@@ -1,0 +1,10 @@
+import { useState } from "react";
+export function useShouldRunQuery(){
+    const [shouldRunQuery, setShouldRunQuery] = useState(false);
+    const onExpand = () => setShouldRunQuery(true)
+    console.log("useShouldrunquery");
+    
+    return {
+        shouldRunQuery, onExpand
+    }
+}


### PR DESCRIPTION
### 💡 Summary

This PR introduces a hybrid approach to determine whether an album has photos (`hasPhotos`), without triggering premature API requests.

---

### 🧠 Approach

Instead of directly relying on either:

* the initial `_count.photos` from the `album`, or
* the result of `useFetchPhotosQuery`,

we now use a **hybrid** strategy.

---

### 🧩 How it works

1. **Initial Count**
   We start by accessing `album._count.photos`. This is a static count (e.g., from a relation count in the DB) and does **not** require an API call.

2. **Delaying the Fetch**
   To prevent `useFetchPhotosQuery` from firing **before** `<PhotosList />` is rendered:

   * We introduce a custom hook: `useShouldRunQuery()`.
   * This hook returns:

     * `shouldRunQuery` → a boolean to control when the query should run.
     * `onExpand()` → a function that sets `shouldRunQuery` to `true`. Called from `PhotosList` on initial render.

3. **Skipping the Query**
   In `useHasPhotos(album, shouldRunQuery)`:

   * If `shouldRunQuery` is `false`, we pass `skipToken` to `useFetchPhotosQuery`, preventing it from initializing or fetching.
   * While skipped, we fall back to the `initialCount` from the album.
   * Once `shouldRunQuery` becomes `true`, the query runs (if it hasn’t already) or reuses cached data.
   * We derive `hasPhotos` based on `!!data.length` (from query) or `initialCount > 0`.

4. **Usage**
   This logic is used in `AlbumsListItem` to decide whether to open a **deletion warning modal** (if `hasPhotos === true`).

---

### 📈 Benefits

* Prevents unnecessary API calls.
* Keeps UI fast by deferring expensive fetches.
* Ensures modal logic always reflects up-to-date state **once PhotosList is mounted**.

---

### 🔗 Related

Fixes: #1 

---

### 🧪 Test Plan

* Click to expand album → triggers `onExpand`.
* Query runs only after `PhotosList` renders.
* Deletion modal respects real-time photo presence.

---

### ✅ Final Thoughts

This change decouples photo-fetch timing from `AlbumsListItem` and pushes it toward the actual consumer (`PhotosList`).